### PR TITLE
Hífen na linha digitável do boleto

### DIFF
--- a/src/Bancos/BancoBrasil/Convenio.php
+++ b/src/Bancos/BancoBrasil/Convenio.php
@@ -32,7 +32,7 @@ use Umbrella\YaBoleto\Type\Number;
 
 /**
  * Classe que representa o convênio do Banco do Brasil.
- * 
+ *
  * @author  Italo Lelis <italolelis@lellysinformatica.com>
  * @package YaBoleto
  */
@@ -40,7 +40,7 @@ class Convenio extends AbstractConvenio
 {
     /**
      * Gera o campo livre do código de barras.
-     * 
+     *
      * @param  ArrayObject $data
      * @return $data
      */
@@ -92,7 +92,7 @@ class Convenio extends AbstractConvenio
         switch (strlen($this->convenio)) {
             case 6:
                 if (!$carteira instanceof Carteira21) {
-                    $data['NossoNumero'] = $this->convenio . Number::modulo11($data['NossoNumero'], 0, 0, true);
+                    $data['NossoNumero'] = $this->convenio . $data['NossoNumero'];
                 }
                 break;
             case 4:

--- a/tests/BancoBrasil/Boleto/BoletoBancoBrasilTest.php
+++ b/tests/BancoBrasil/Boleto/BoletoBancoBrasilTest.php
@@ -29,7 +29,7 @@ class BoletoBancoBrasilTest extends BoletoTestCase
     {
         $carteira = new Carteira18();
 
-        return new Convenio($this->bancoProvider(), $carteira, "1643044", "2");
+        return new Convenio($this->bancoProvider(), $carteira, "164304", "2");
     }
 
     protected function convenio184Provider()
@@ -103,9 +103,9 @@ class BoletoBancoBrasilTest extends BoletoTestCase
         list($sacado, $cedente) = $pessoa;
         $boleto = new BoletoBancoBrasil($sacado, $cedente, $convenio);
         $boleto->setValorDocumento(1.00)
-               ->setNumeroDocumento("024588722")
-               ->setDataVencimento(new Carbon("2013-11-02"))
-               ->gerarCodigoBarraLinhaDigitavel();
+            ->setNumeroDocumento("024588722")
+            ->setDataVencimento(new Carbon("2013-11-02"))
+            ->gerarCodigoBarraLinhaDigitavel();
 
         $this->assertNotEmpty($boleto);
     }
@@ -118,9 +118,9 @@ class BoletoBancoBrasilTest extends BoletoTestCase
         list($sacado, $cedente) = $pessoa;
         $boleto = new BoletoBancoBrasil($sacado, $cedente, $convenio);
         $boleto->setValorDocumento("1.500,00")
-                ->setNumeroDocumento("23456")
-                ->setDataVencimento(new Carbon("2013-11-02"))
-                ->gerarCodigoBarraLinhaDigitavel();
+            ->setNumeroDocumento("23456")
+            ->setDataVencimento(new Carbon("2013-11-02"))
+            ->gerarCodigoBarraLinhaDigitavel();
 
         $this->assertNotEmpty($boleto);
     }
@@ -134,10 +134,10 @@ class BoletoBancoBrasilTest extends BoletoTestCase
         list($sacado, $cedente) = $pessoa;
         $boleto = new BoletoBancoBrasil($sacado, $cedente, $convenio);
         $boleto->setValorDocumento(1.00)
-                ->setDesconto(2.00)
-                ->setNumeroDocumento("024588722")
-                ->setDataVencimento(new Carbon("2013-11-02"))
-                ->gerarCodigoBarraLinhaDigitavel();
+            ->setDesconto(2.00)
+            ->setNumeroDocumento("024588722")
+            ->setDataVencimento(new Carbon("2013-11-02"))
+            ->gerarCodigoBarraLinhaDigitavel();
 
         $this->assertNotEmpty($boleto);
     }
@@ -153,6 +153,54 @@ class BoletoBancoBrasilTest extends BoletoTestCase
         $boleto->setValorDocumento(null);
         $boleto->validarDadosObrigatorios();
         $this->assertNotEmpty($boleto->getErros());
+    }
+
+    /**
+     * @dataProvider boletoProvider
+     */
+    public function testShouldValiteSizeOurNumberConvenioSizeFour($pessoa)
+    {
+        list($sacado, $cedente) = $pessoa;
+        $convenio = $this->convenio184Provider();
+        $boleto = new BoletoBancoBrasil($sacado, $cedente, $convenio);
+        $boleto->setValorDocumento(1.00)
+            ->setNumeroDocumento("024588722")
+            ->setDataVencimento(new Carbon("2013-11-02"))
+            ->gerarCodigoBarraLinhaDigitavel();
+
+        $this->assertEquals(11, strlen($boleto->getConvenio()->getNossoNumero()));
+    }
+
+    /**
+     * @dataProvider boletoProvider
+     */
+    public function testShouldValiteSizeOurNumberConvenioSizeSix($pessoa)
+    {
+        list($sacado, $cedente) = $pessoa;
+        $convenio = $this->convenio186Provider();
+        $boleto = new BoletoBancoBrasil($sacado, $cedente, $convenio);
+        $boleto->setValorDocumento(1.00)
+            ->setNumeroDocumento("024588722")
+            ->setDataVencimento(new Carbon("2013-11-02"))
+            ->gerarCodigoBarraLinhaDigitavel();
+
+        $this->assertEquals(11, strlen($boleto->getConvenio()->getNossoNumero()));
+    }
+
+    /**
+     * @dataProvider boletoProvider
+     */
+    public function testShouldValiteSizeOurNumberConvenioSizeSeven($pessoa)
+    {
+        list($sacado, $cedente) = $pessoa;
+        $convenio = $this->convenio187Provider();
+        $boleto = new BoletoBancoBrasil($sacado, $cedente, $convenio);
+        $boleto->setValorDocumento(1.00)
+            ->setNumeroDocumento("024588722")
+            ->setDataVencimento(new Carbon("2013-11-02"))
+            ->gerarCodigoBarraLinhaDigitavel();
+
+        $this->assertEquals(17, strlen($boleto->getConvenio()->getNossoNumero()));
     }
 
 }


### PR DESCRIPTION
Removendo o calculo do modulo11 do método ajustarNossoNumero pois esse método estava fazendo a aplicação fazer o cálculo do modulo11 duas vezes resultando no hífen na linha digitável.