### PR TITLE
Versão da library de validação

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
   ],
   "require": {
     "php": ">=5.3",
-    "respect/validation": "~0.9.0"
+    "respect/validation": "~0.9.0|^1.1"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.8"


### PR DESCRIPTION
Configurei a dependência para utilizar a última versão do Respect mas mantendo suporte à versão `0.9` (Algumas aplicações podem utilizar essa versão e aí evitamos de quebrá-las numa futura minor version aqui lançada).

**Nota:** Ambas as versões funcionam bem para o ya-boleto e sem quebra de API.