### PR TITLE
Fix na ordem do fator no modulo10

### DIFF
--- a/src/Type/Number.php
+++ b/src/Type/Number.php
@@ -111,7 +111,7 @@ class Number
         $parcial10 = array();
 
         // Separacao dos numeros
-        for ($i = strlen($num); $i > 0; $i--) {
+        for ($i = 1; $i <= strlen($num); $i++) {
             // pega cada numero isoladamente
             $numeros[$i] = substr($num, $i - 1, 1);
             // Efetua multiplicacao do numero pelo (falor 10)


### PR DESCRIPTION
A ordem do cálculo do modulo10 estava incorreta fazendo com que o fator(peso) de cálculo ficasse incorreto.