### PR TITLE
Corrigindo erro de regra no cálculo do Nosso Número

### DIFF
--- a/src/Bancos/Banese/Convenio.php
+++ b/src/Bancos/Banese/Convenio.php
@@ -68,7 +68,7 @@ class Convenio extends AbstractConvenio
 
         //Retorna o valor arredondado do resto da soma dividida por 11
         $resto = round(($soma % 11));
-        $dv = 0 == $resto || 1 == $resto ? $resto : round(11 - $resto);
+        $dv = 0 == $resto || 1 == $resto ? 0 : round(11 - $resto);
 
         return $dv;
     }


### PR DESCRIPTION
Corrigindo erro de regra no retorno do resultado do cálculo do digito verificador do Nosso Número.

5. O dígito será encontrado fazendo-se o seguinte teste:
SE RESTO = 0 OU 1
ENTAO DIGITO = ZEROS
SENAO DIGITO = 11 – RESTO