### PR TITLE
correção de arredondamento no método format (Number)

### DIFF
--- a/src/Type/Number.php
+++ b/src/Type/Number.php
@@ -41,7 +41,7 @@ class Number
      */
     public static function format($number)
     {
-        return (int)($number * 100);
+        return ($number * 100);
     }
 
     /**


### PR DESCRIPTION
Correção do método format que, em alguns casos, no cast para inteiro, gerava erro de arredondamento, por exemplo no número 35,80, o valor retornado pelo método era 35,79. Esse erro ocorreu por conta da forma que o PHP trabalha com número de ponto flutuante, mais informações em http://php.net/manual/pt_BR/language.types.float.php.
